### PR TITLE
Record audit-directory-layout state

### DIFF
--- a/findings/kitsuyui/kitsuyui/_audit-state.yaml
+++ b/findings/kitsuyui/kitsuyui/_audit-state.yaml
@@ -10,3 +10,12 @@ categories:
       agent: codex
       model: gpt-5.5-extra-high
       context: automation-issue-loop
+  audit-directory-layout:
+    last_checked_at: 2026-05-22T14:36:27+09:00
+    last_checked_target_commit: 6a44ac04d76bd10ee82898708ed6acf978d93f92
+    last_checked_basis_commit: 13a56bf9cc89f13a4376f37188352242766f3a8e
+    last_run_by:
+      type: agent
+      agent: codex
+      model: gpt-5.5-extra-high
+      context: automation-issue-loop


### PR DESCRIPTION
## Summary
- Recorded the current audit state for `audit-directory-layout`.
- No separate finding was added because the repository layout is intentionally minimal.

## Validation
- `git diff --check`
- `python3 ../kimono-tasks/scripts/check-findings.py --skip-transitions`
- `python3 ../kimono-tasks/scripts/scheduling/provenance-check.py`