### PR TITLE
Record docs audit state

### DIFF
--- a/findings/kitsuyui/kitsuyui/_audit-state.yaml
+++ b/findings/kitsuyui/kitsuyui/_audit-state.yaml
@@ -10,3 +10,12 @@ categories:
       agent: codex
       model: gpt-5.5-extra-high
       context: automation-issue-loop
+  docs:
+    last_checked_at: 2026-05-22T19:36:28+09:00
+    last_checked_target_commit: a08ae5fba8df9190df7ee17b9dda22ec64711f90
+    last_checked_basis_commit: 13a56bf9cc89f13a4376f37188352242766f3a8e
+    last_run_by:
+      type: agent
+      agent: codex
+      model: gpt-5.5-extra-high
+      context: automation-issue-loop


### PR DESCRIPTION
## Summary
- Recorded the current audit state for `docs`.
- No separate finding was added.

## Validation
- `git diff --check`
- `python3 ../kimono-tasks/scripts/check-findings.py --skip-transitions`
- `python3 ../kimono-tasks/scripts/scheduling/provenance-check.py`