### PR TITLE
Refresh audit-cli-ux-discipline state

### DIFF
--- a/findings/kitsuyui/kitsuyui/_audit-state.yaml
+++ b/findings/kitsuyui/kitsuyui/_audit-state.yaml
@@ -2,8 +2,8 @@ schema_version: 1
 repo: kitsuyui/kitsuyui
 categories:
   audit-cli-ux-discipline:
-    last_checked_at: 2026-05-22T14:36:27+09:00
-    last_checked_target_commit: 6a44ac04d76bd10ee82898708ed6acf978d93f92
+    last_checked_at: 2026-05-22T21:40:28+09:00
+    last_checked_target_commit: 03ae54331fb3f6a3fc8eb40b53bfd779dac4d07d
     last_checked_basis_commit: 13a56bf9cc89f13a4376f37188352242766f3a8e
     last_run_by:
       type: agent


### PR DESCRIPTION
Refresh the audit state for audit-cli-ux-discipline to match the current HEAD. No findings were added; only _audit-state.yaml was updated.