### PR TITLE
docs: remove duplicate contribution URL

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -15,7 +15,6 @@ A list of repositories I contributed to
 - https://github.com/Microsoft/homebrew-mssql-release/issues/18
 - https://github.com/python/python-docs-ja/pull/9
 - https://github.com/eoranged/rq-dashboard/pull/158
-- https://github.com/Microsoft/homebrew-mssql-release/issues/18
 - https://github.com/renovateapp/renovate/pull/1930
 - https://github.com/crsmithdev/arrow/pull/312
 - https://github.com/claudetech/python-slack-log/pull/5


### PR DESCRIPTION
## What

Remove a duplicate entry from `contributions.md`.
`https://github.com/Microsoft/homebrew-mssql-release/issues/18` appeared
twice (lines 15 and 18), which was unintentional.

## Why

Duplicate entries reduce list readability and signal the list was not
carefully curated. The URL appears once in the correct position; the
second occurrence is removed.

## Changes

| File | Change |
|---|---|
| `contributions.md` | Remove duplicate line 18 |
