### PR TITLE
docs: separate non-GitHub URL from GitHub contributions list

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -38,4 +38,7 @@ A list of repositories I contributed to
 - https://github.com/horike37/serverless-step-functions/pull/30
 - https://github.com/dmarmor/epichrome/issues/85#issuecomment-256107908
 - https://github.com/mikoto2000/embulk-input-salesforce_bulk/issues/4#issuecomment-281945126
+
+# External mentions
+
 - https://twitter.com/taku910/status/556466893280645120


### PR DESCRIPTION
## Summary

`contributions.md` declares "A list of repositories I contributed to" but included a
Twitter URL (`https://twitter.com/taku910/status/556466893280645120`) as its last
entry alongside GitHub PR/issue links. The Twitter URL is not a GitHub repository
contribution and created an inconsistency between the file's stated purpose and its
content.

This PR moves the Twitter link out of the GitHub contributions list and into a new
`# External mentions` section, preserving the record while making the file
self-consistent.

## Changes

- `contributions.md`: moved the Twitter URL from `# list` to a new `# External mentions` section

## Verification

- No functional change; purely documentation restructuring
- The `# list` section now contains only GitHub PR/issue URLs
